### PR TITLE
feat(auth): allow's users to pass in auth to the cluster

### DIFF
--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -1,4 +1,4 @@
-import type { ClusterConfig, ScyllaSession } from "@lambda-group/scylladb";
+import type { ClusterConfig, ConnectionOptions, ScyllaSession } from "@lambda-group/scylladb";
 import { Cluster } from "@lambda-group/scylladb";
 import type { BaseEntity } from "./entity/base";
 import { Repository } from "./repository/base";
@@ -11,8 +11,8 @@ export class DataSource {
 		this.cluster = new Cluster(this.options);
 	}
 
-	async initialize(keyspace?: string): Promise<DataSource> {
-		this.session = await this.cluster.connect(keyspace);
+	async initialize(keyspaceOrOptions?: string | ConnectionOptions): Promise<DataSource> {
+		this.session = await this.cluster.connect(keyspaceOrOptions);
 
 		return this;
 	}


### PR DESCRIPTION
This pull request allows users to authenticate since currently, they can only pass the keyspace in initialization. A better solution would probably be to allow them to pass it when they create the instance(?) but for now, this should work.